### PR TITLE
Remove Apple PowerPC code

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -42,18 +42,9 @@
 #include <fcntl.h>
 #endif
 
-#if defined(__APPLE__) && defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
-#define MAC_OS_10_6_DETECTED
-#endif
-
-/* Define valkey_fstat to fstat or fstat64() */
-#if defined(__APPLE__) && !defined(MAC_OS_10_6_DETECTED)
-#define valkey_fstat fstat64
-#define valkey_stat stat64
-#else
+/* Define valkey_fstat to fstat */
 #define valkey_fstat fstat
 #define valkey_stat stat
-#endif
 
 /* Test for proc filesystem */
 #ifdef __linux__
@@ -112,7 +103,7 @@
 #endif
 
 /* Detect for kqueue */
-#if (defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)) || defined(__DragonFly__) || defined(__FreeBSD__) || \
+#if defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__) || \
     defined(__OpenBSD__) || defined(__NetBSD__)
 #define HAVE_KQUEUE 1
 #endif
@@ -236,7 +227,7 @@ void setproctitle(const char *fmt, ...);
     defined(ibm032) || defined(ibm370) || defined(MIPSEB) || defined(_MIPSEB) || defined(_IBMR2) || defined(DGUX) || \
     defined(apollo) || defined(__convex__) || defined(_CRAY) || defined(__hppa) || defined(__hp9000) ||              \
     defined(__hp9000s300) || defined(__hp9000s700) || defined(BIT_ZERO_ON_LEFT) || defined(m68k) ||                  \
-    defined(__sparc) || (defined(__APPLE__) && defined(__POWERPC__))
+    defined(__sparc)
 #define BYTE_ORDER BIG_ENDIAN
 #endif
 #endif /* linux */

--- a/src/debug.c
+++ b/src/debug.c
@@ -1206,24 +1206,11 @@ static void *getAndSetMcontextEip(ucontext_t *uc, void *eip) {
         }                                       \
         return old_val;                         \
     } while (0)
-#if defined(__APPLE__) && !defined(MAC_OS_10_6_DETECTED)
-/* OSX < 10.6 */
-#if defined(__x86_64__)
-    GET_SET_RETURN(uc->uc_mcontext->__ss.__rip, eip);
-#elif defined(__i386__)
-    GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
-#else
-    /* OSX PowerPC */
-    GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
-#endif
-#elif defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
-/* OSX >= 10.6 */
+#if defined(__APPLE__)
 #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
     GET_SET_RETURN(uc->uc_mcontext->__ss.__rip, eip);
 #elif defined(__i386__)
     GET_SET_RETURN(uc->uc_mcontext->__ss.__eip, eip);
-#elif defined(__ppc__)
-    GET_SET_RETURN(uc->uc_mcontext->__ss.__srr0, eip);
 #else
     /* OSX ARM64 */
     void *old_val = (void *)arm_thread_state64_get_pc(uc->uc_mcontext->__ss);
@@ -1313,7 +1300,7 @@ void logRegisters(ucontext_t *uc) {
     } while (0)
 
 /* OSX */
-#if defined(__APPLE__) && defined(MAC_OS_10_6_DETECTED)
+#if defined(__APPLE__)
     /* OSX AMD64 */
 #if defined(_STRUCT_X86_THREAD_STATE64) && !defined(__i386__)
     serverLog(LL_WARNING,
@@ -1386,7 +1373,6 @@ void logRegisters(ucontext_t *uc) {
         (unsigned long)arm_thread_state64_get_pc(uc->uc_mcontext->__ss), (unsigned long)uc->uc_mcontext->__ss.__cpsr);
     logStackContent((void **)arm_thread_state64_get_sp(uc->uc_mcontext->__ss));
 #else
-    /* At the moment we do not implement this for PowerPC */
     NOT_SUPPORTED();
 #endif
 /* Linux */


### PR DESCRIPTION
## Summary
- drop MAC_OS_10_6_DETECTED logic and old fstat64 usage
- remove Apple PowerPC and ancient OS X conditionals

## Testing
- `make test` *(fails: interrupted due to time)*

------
https://chatgpt.com/codex/tasks/task_e_6849f44b79c0832688849e28f48bcd6f