### PR TITLE
test: expand wait for slave selection

### DIFF
--- a/tests/unit/cluster/slave-selection.tcl
+++ b/tests/unit/cluster/slave-selection.tcl
@@ -106,7 +106,7 @@ test "Cluster should eventually be up again" {
 test "Node #10 should eventually replicate node #5" {
     set port5 [srv -5 port]
     # Valgrind runs are significantly slower and occasionally need more time
-    # for the cluster to propagate the new master. Use a larger timeout to
+    # for the cluster to propagate the new primary. Use a larger timeout to
     # avoid spurious failures in slow environments.
     wait_for_condition 2000 50 {
         ([lindex [R 10 role] 2] == $port5) &&

--- a/tests/unit/cluster/slave-selection.tcl
+++ b/tests/unit/cluster/slave-selection.tcl
@@ -105,7 +105,10 @@ test "Cluster should eventually be up again" {
 
 test "Node #10 should eventually replicate node #5" {
     set port5 [srv -5 port]
-    wait_for_condition 1000 50 {
+    # Valgrind runs are significantly slower and occasionally need more time
+    # for the cluster to propagate the new master. Use a larger timeout to
+    # avoid spurious failures in slow environments.
+    wait_for_condition 2000 50 {
         ([lindex [R 10 role] 2] == $port5) &&
         ([lindex [R 10 role] 3] eq {connected})
     } else {


### PR DESCRIPTION
## Summary
- extend replication wait time in `slave-selection` test

## Testing
- `./runtest --single unit/cluster/slave-selection`
- `./runtest --single unit/cluster/slave-selection --valgrind`


------
https://chatgpt.com/codex/tasks/task_e_68c32afdf3ec8326bd84f3d3c825dd14